### PR TITLE
Analytics update for orders with products of different qualities

### DIFF
--- a/common/src/main/scala/de/hpi/epic/pricewars/logging/flink/MarketshareInputEntry.scala
+++ b/common/src/main/scala/de/hpi/epic/pricewars/logging/flink/MarketshareInputEntry.scala
@@ -11,5 +11,5 @@ class MarketshareInputEntry(val merchant_id: Token, val amount: Amount) extends 
 
 object MarketshareInputEntry {
   def from(entry: BuyOfferEntry): MarketshareInputEntry = new MarketshareInputEntry(entry.merchant_id, entry.amount)
-  def from(entry: Order): MarketshareInputEntry = new MarketshareInputEntry(entry.merchant_id, entry.amount)
+  def from(order: Order): MarketshareInputEntry = new MarketshareInputEntry(order.merchant_id, order.quantity)
 }

--- a/common/src/main/scala/de/hpi/epic/pricewars/logging/producer/Order.scala
+++ b/common/src/main/scala/de/hpi/epic/pricewars/logging/producer/Order.scala
@@ -1,8 +1,8 @@
 package de.hpi.epic.pricewars.logging.producer
 
-import de.hpi.epic.pricewars.logging.base.{AmountEntry, MerchantIDEntry, TimestampEntry}
+import de.hpi.epic.pricewars.logging.base.{MerchantIDEntry, TimestampEntry}
 import de.hpi.epic.pricewars.types._
 
 case class Order(billing_amount: Currency, product_id: ID, name: Name, unit_price: Currency,
-                 amount: Amount, merchant_id: Token, timestamp: Timestamp)
-  extends MerchantIDEntry with AmountEntry with TimestampEntry
+                 quantity: Quantity, merchant_id: Token, timestamp: Timestamp)
+  extends MerchantIDEntry with TimestampEntry

--- a/common/src/main/scala/de/hpi/epic/pricewars/logging/producer/Order.scala
+++ b/common/src/main/scala/de/hpi/epic/pricewars/logging/producer/Order.scala
@@ -1,11 +1,8 @@
 package de.hpi.epic.pricewars.logging.producer
 
-import de.hpi.epic.pricewars.logging.base.{AmountEntry, MerchantIDEntry, PriceEntry, TimestampEntry}
+import de.hpi.epic.pricewars.logging.base.{AmountEntry, MerchantIDEntry, TimestampEntry}
 import de.hpi.epic.pricewars.types._
 
-/**
-  * Created by Jan on 30.11.2016.
-  */
-case class Order(billing_amount: Currency, uid: ID, product_id: ID, name: Name, quality: Quality, price: Currency, amount: Amount,
-                 signature: Signature, merchant_id: Token, timestamp: Timestamp)
-  extends MerchantIDEntry with AmountEntry with PriceEntry with TimestampEntry
+case class Order(billing_amount: Currency, product_id: ID, name: Name, unit_price: Currency,
+                 amount: Amount, merchant_id: Token, timestamp: Timestamp)
+  extends MerchantIDEntry with AmountEntry with TimestampEntry

--- a/common/src/main/scala/de/hpi/epic/pricewars/types/package.scala
+++ b/common/src/main/scala/de/hpi/epic/pricewars/types/package.scala
@@ -7,6 +7,7 @@ import org.joda.time.DateTime
   */
 package object types {
   type Amount = Int
+  type Quantity = Int
   type Currency = BigDecimal
   type HttpCode = Int
   type ID = Long

--- a/holdingCost/src/main/scala/de/hpi/epic/pricewars/analytics/HoldingCost.scala
+++ b/holdingCost/src/main/scala/de/hpi/epic/pricewars/analytics/HoldingCost.scala
@@ -35,7 +35,7 @@ object HoldingCost {
         properties withClientId clientIdPrefix
       ))
 
-    val fillingStream = orderStream.map(e => InventoryLevel(e.merchant_id, e.amount, e.timestamp))
+    val fillingStream = orderStream.map(e => InventoryLevel(e.merchant_id, e.quantity, e.timestamp))
     val emptyingStream = saleStream
       .filter(e => e.http_code == 200)
       .map(e => InventoryLevel(e.merchant_id, -1 * e.amount, e.timestamp))


### PR DESCRIPTION
The structure of a producer order changed.
I made some adjustments to the order class to work with the new order format.
All attributes that are used by Flink programs are unchanged (`billing_amount, amount, merchant_id, timestamp`).