### PR TITLE
Increase number of task slots to 8

### DIFF
--- a/start-taskmanager.sh
+++ b/start-taskmanager.sh
@@ -5,7 +5,7 @@
 # Edit config file to suppress INFO messages on console
 find /opt/flink/conf -type f -exec sed -i "s/INFO, console/WARN, console/g" {} \;
 
-/opt/flink/bin/docker-entrypoint.sh taskmanager &
+/opt/flink/bin/docker-entrypoint.sh taskmanager taskmanager.numberOfTaskSlots=8 &
 
 # Getting the process and waiting for it to ensure the container will stay up
 PID_TASKMANAGER=$!


### PR DESCRIPTION
Price Wars currently requires 4 slots to run its 4 jobs. Dual core machines will only provide two slots though. This results in a failure to generate the profit and revenue statistics. This PR therefore updates the number of slots to 8, regardless of the CPU count. I've opted for 8 to be a bit more future-proof. 

I've seen the other PRs which switch to the official Docker images. 
I wanted to create this PR just for reference. This is probably something you should look into with the official images as well.

//cc @KBorchar @frederike-ramin 